### PR TITLE
ci: Re-enable tests 

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -3,12 +3,6 @@ set -e
 
 cd $(dirname $0)
 
-# Disable tests because the error that needs to be fixed
-# exit status 20 ("failed to execute: /usr/bin/nsenter [nsenter iscsiadm -m discovery -t sendtargets -p 172.17.0.3], 
-# output , stderr System has not been booted with systemd as init system (PID 1). Can't operate.\nFailed to connect to bus:
-# Host is down\niscsiadm: can not connect to iSCSI daemon (111)!\nSystem has not been booted with systemd as init system (PID 1). Can't operate.\n
-# Failed to connect to bus: Host is down\niscsiadm: can not connect to iSCSI daemon (111)!\niscsiadm: Cannot perform discovery. Initiatorname required.\n
-# iscsiadm: Could not perform SendTargets discovery: could not connect to iscsid\n: exit status 20")
-#./test
+./test
 
 ./validate


### PR DESCRIPTION
Debug why tests was disabled on https://github.com/longhorn/go-iscsi-helper/pull/86/